### PR TITLE
Schmetterling contains AOT'd classfiles on clojars.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,12 +23,12 @@
   :repl-options {:host "localhost"
                  :port 11911}
   :main ^:skip-aot schmetterling.server
-  :cljsbuild 
-  {:builds 
-   {:dev 
+  :cljsbuild
+  {:builds
+   {:dev
     {:libs ["singult"]
-     :source-paths ["src/cljs"]  
-     :compiler 
+     :source-paths ["src/cljs"]
+     :compiler
      {:externs ["resources/public/js/externs/greensock.externs.js"]
       :optimizations :whitespace
       :output-to  "resources/public/js/app/schmetterling.js"

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
   :min-lein-version "2.0.0"
   :repl-options {:host "localhost"
                  :port 11911}
-  :main schmetterling.server
+  :main ^:skip-aot schmetterling.server
   :cljsbuild 
   {:builds 
    {:dev 


### PR DESCRIPTION
This cleans up `project.clj` to avoid accidentally putting class files in library jars.

The currently-deployed 0.0.7 version contains a bunch of outdated classfiles, causing difficult-to-debug issues like this: https://github.com/caribou/caribou-development/commit/ec3b8d194fa0def30d18e1f4cd8deffecf631b3d#commitcomment-5530840

I recommend pushing out a bugfix version with no AOT soon.
